### PR TITLE
Disabled quiz autoscale due to bug

### DIFF
--- a/js/scriptquiz.js
+++ b/js/scriptquiz.js
@@ -48,7 +48,7 @@ $(document).ready(function () {
 	$('#correctFeedback').hide()
 	selectDrugs();
 	PlotQuizSchild("quizschild",0.2, false)
-	document.querySelector('[data-title="Autoscale"]').click();
+	//document.querySelector('[data-title="Autoscale"]').click();
 	PlotQuizSchild("actualanswer",1.0, true)
 	PlotQuizSchild("correctanswer",1.0, true)
 	document.getElementById("loader").style.display = "none";


### PR DESCRIPTION
For some reason, toolbar settings have stopped appearing on the quiz plot. Because of this new behaviour, the quiz page was not loading succesfully. Automatic auto-scaling has been disabled for the time being,